### PR TITLE
Added the volunteers page and the detail page for each volunteer

### DIFF
--- a/app-next/app/volunteers/[id]/page.jsx
+++ b/app-next/app/volunteers/[id]/page.jsx
@@ -1,0 +1,6 @@
+"use client";
+import VolunteerDetail from "@/components/VolunteerDetail/VolunteerDetail";
+
+export default function VolunteerDetailPage({ params }) {
+  return <VolunteerDetail volunteerId={params.id} />;
+}

--- a/app-next/app/volunteers/page.jsx
+++ b/app-next/app/volunteers/page.jsx
@@ -1,0 +1,6 @@
+"use client";
+import VolunteerList from "@/components/VolunteerList/VolunteerList";
+
+export default function VolunteersPage() {
+  return <VolunteerList />;
+}

--- a/app-next/components/Header/Header.jsx
+++ b/app-next/components/Header/Header.jsx
@@ -35,7 +35,7 @@ export default function Header() {
             <Link href="/">Home</Link>
           </li>
           <li>
-            <Link href="/request-help">Request Help</Link>
+            <Link href="/volunteers">Volunteers</Link>
           </li>
           <li>
             <Link href="/offer-help">Offer Help</Link>

--- a/app-next/components/HomePage/HomePage.jsx
+++ b/app-next/components/HomePage/HomePage.jsx
@@ -5,26 +5,26 @@ export default function Homepage() {
   return (
     <div className={styles.container}>
       {/* Hero Section */}
-     <section className={styles.hero}>
-  <div className={styles.heroCard}>
-    <h1>CareConnect</h1>
-    <p>Connecting elderly people with helpers in their community</p>
-    <div className={styles["button-group"]}>
-      <Link
-        href="/request-help"
-        className={`${styles.button} ${styles.request}`}
-      >
-        Request Help
-      </Link>
-      <Link
-        href="/offer-help"
-        className={`${styles.button} ${styles.offer}`}
-      >
-        Offer Help
-      </Link>
-    </div>
-  </div>
-</section>
+      <section className={styles.hero}>
+        <div className={styles.heroCard}>
+          <h1>CareConnect</h1>
+          <p>Connecting elderly people with helpers in their community</p>
+          <div className={styles["button-group"]}>
+            <Link
+              href="/volunteers"
+              className={`${styles.button} ${styles.request}`}
+            >
+              Volunteers
+            </Link>
+            <Link
+              href="/offer-help"
+              className={`${styles.button} ${styles.offer}`}
+            >
+              Offer Help
+            </Link>
+          </div>
+        </div>
+      </section>
 
       {/* Features Section */}
       <section className={styles.features}>

--- a/app-next/components/Volunteer/Volunteer.jsx
+++ b/app-next/components/Volunteer/Volunteer.jsx
@@ -1,0 +1,45 @@
+import React from "react";
+import styles from "./Volunteer.module.css";
+import Link from "next/link";
+
+const Volunteer = ({ volunteer }) => {
+  return (
+    <div className={styles.volunteer}>
+      <div className={styles.imageContainer}>
+        {volunteer.photo ? (
+          <img
+            src={volunteer.photo}
+            alt={volunteer.name}
+            className={styles.volunteerImage}
+          />
+        ) : (
+          <div className={styles.placeholder}>
+            <span>No Photo</span>
+          </div>
+        )}
+      </div>
+
+      <div className={styles.content}>
+        <h3 className={styles.name}>{volunteer.name}</h3>
+        <p className={styles.address}>{volunteer.address}</p>
+        <p className={styles.services}>
+          Services:{" "}
+          {volunteer.services?.length
+            ? volunteer.services.join(", ")
+            : "Not specified"}
+        </p>
+        <p className={styles.availability}>
+          Availability: {volunteer.availability || "Not specified"}
+        </p>
+        <Link
+          href={`/volunteers/${volunteer.id}`}
+          className={styles.detailsButton}
+        >
+          See Details
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default Volunteer;

--- a/app-next/components/Volunteer/Volunteer.module.css
+++ b/app-next/components/Volunteer/Volunteer.module.css
@@ -1,0 +1,85 @@
+.volunteer {
+  background: white;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.1);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  display: flex;
+  flex-direction: column;
+}
+
+.volunteer:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
+}
+
+.imageContainer {
+  width: 100%;
+  height: 220px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.volunteerImage {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.placeholder {
+  background-color: #f0f0f0;
+  color: #777;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  width: 100%;
+  height: 100%;
+}
+
+.content {
+  padding: 16px 20px;
+}
+
+.name {
+  font-size: 20px;
+  font-weight: bold;
+  color: #333;
+  margin-bottom: 8px;
+}
+
+.address {
+  font-size: 14px;
+  color: #666;
+  margin-bottom: 10px;
+}
+
+.services {
+  font-size: 14px;
+  color: #444;
+  margin-bottom: 15px;
+}
+
+.availability {
+  font-size: 14px;
+  color: #444;
+  margin-bottom: 10px;
+}
+
+.detailsButton {
+  display: inline-block;
+  padding: 10px 18px;
+  background-color: #1e90ff;
+  color: white;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background-color 0.3s ease;
+}
+
+.detailsButton:hover {
+  background-color: #0066cc;
+}

--- a/app-next/components/VolunteerDetail/VolunteerDetail.jsx
+++ b/app-next/components/VolunteerDetail/VolunteerDetail.jsx
@@ -1,0 +1,92 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import styles from "./VolunteerDetail.module.css";
+import { useRouter } from "next/navigation";
+
+const mockVolunteers = [
+  {
+    id: 1,
+    name: "Anna Smith",
+    email: "anna@example.com",
+    phone_nr: "12345678",
+    address: "Copenhagen",
+    photo: "/images/volunteer1.jpg",
+    services: ["Shopping", "Cooking"],
+    gender: "Female",
+    routine: "Morning",
+    availability: "Weekdays, 9am - 1pm",
+  },
+  {
+    id: 2,
+    name: "John Doe",
+    email: "john@example.com",
+    phone_nr: "87654321",
+    address: "Aarhus",
+    photo: "/images/volunteer2.jpg",
+    services: ["Gardening", "Companionship"],
+    gender: "Male",
+    routine: "Evening",
+    availability: "Weekends, 4pm - 8pm",
+  },
+];
+
+const VolunteerDetail = ({ volunteerId }) => {
+  const [volunteer, setVolunteer] = useState(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    const v = mockVolunteers.find((v) => v.id === Number(volunteerId));
+    setVolunteer(v);
+  }, [volunteerId]);
+
+  if (!volunteer) return <p>Loading volunteer details...</p>;
+
+  return (
+    <div className={styles.container}>
+      <button onClick={() => router.back()} className={styles.backButton}>
+        ← Back
+      </button>
+
+      <div className={styles.header}>
+        <h1>{volunteer.name}</h1>
+      </div>
+
+      <div className={styles.details}>
+        <div className={styles.imageContainer}>
+          {volunteer.photo ? (
+            <img src={volunteer.photo} alt={volunteer.name} />
+          ) : (
+            <div className={styles.placeholder}></div>
+          )}
+        </div>
+
+        <div className={styles.info}>
+          <p>
+            <strong>Email:</strong> {volunteer.email}
+          </p>
+          <p>
+            <strong>Phone:</strong> {volunteer.phone_nr}
+          </p>
+          <p>
+            <strong>Address:</strong> {volunteer.address}
+          </p>
+          <p>
+            <strong>Gender:</strong> {volunteer.gender}
+          </p>
+          <p>
+            <strong>Routine:</strong> {volunteer.routine}
+          </p>
+          <p>
+            <strong>Availability:</strong> {volunteer.availability}
+          </p>
+          <p>
+            <strong>Services:</strong> {volunteer.services.join(", ")}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default VolunteerDetail;

--- a/app-next/components/VolunteerDetail/VolunteerDetail.module.css
+++ b/app-next/components/VolunteerDetail/VolunteerDetail.module.css
@@ -1,0 +1,127 @@
+.container {
+  padding: 40px 20px;
+  max-width: 900px;
+  margin: 0 auto;
+  font-family: "Segoe UI", Arial, sans-serif;
+  color: #333;
+}
+
+.backButton {
+  background: none;
+  border: none;
+  color: #1e90ff;
+  font-size: 16px;
+  cursor: pointer;
+  margin-bottom: 20px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  transition: transform 0.2s ease, color 0.3s ease;
+}
+
+.backButton:hover {
+  color: #0066cc;
+  transform: translateX(-3px);
+}
+
+.header {
+  margin-bottom: 30px;
+  text-align: center;
+}
+
+.header h1 {
+  font-size: 2.2rem;
+  font-weight: 700;
+  color: #111;
+  margin-bottom: 10px;
+}
+
+.details {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 30px;
+  align-items: flex-start;
+  background: #fff;
+  border-radius: 16px;
+  padding: 25px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+}
+
+.imageContainer {
+  flex: 1;
+  min-width: 250px;
+  max-width: 350px;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.imageContainer img {
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+}
+
+.placeholder {
+  width: 100%;
+  height: 250px;
+  background: linear-gradient(135deg, #e0e0e0, #f8f8f8);
+  border-radius: 12px;
+}
+
+.info {
+  flex: 2;
+  min-width: 300px;
+}
+
+.info p {
+  margin-bottom: 14px;
+  font-size: 16px;
+  color: #444;
+  line-height: 1.5;
+}
+
+.info strong {
+  display: inline-block;
+  min-width: 100px;
+  color: #111;
+}
+
+.availability {
+  display: inline-block;
+  padding: 6px 12px;
+  margin-top: 8px;
+  background: #e6f4ea;
+  color: #2e7d32;
+  font-size: 14px;
+  font-weight: 600;
+  border-radius: 8px;
+}
+
+.services {
+  margin-top: 12px;
+}
+
+.services span {
+  display: inline-block;
+  background: #f0f7ff;
+  color: #1e90ff;
+  font-size: 14px;
+  font-weight: 500;
+  padding: 6px 10px;
+  border-radius: 8px;
+  margin-right: 6px;
+  margin-bottom: 6px;
+}
+
+@media (max-width: 768px) {
+  .details {
+    flex-direction: column;
+    align-items: center;
+    padding: 20px;
+  }
+
+  .info {
+    text-align: center;
+  }
+}

--- a/app-next/components/VolunteerList/VolunteerList.jsx
+++ b/app-next/components/VolunteerList/VolunteerList.jsx
@@ -1,0 +1,50 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import styles from "./VolunteerList.module.css";
+import Volunteer from "../Volunteer/Volunteer";
+
+const mockVolunteers = [
+  {
+    id: 1,
+    name: "Anna Smith",
+    email: "anna@example.com",
+    address: "Copenhagen",
+    photo: "/images/volunteer1.jpg",
+    services: ["Shopping", "Cooking"],
+    availability: "Weekdays, 9am - 1pm",
+  },
+  {
+    id: 2,
+    name: "John Doe",
+    email: "john@example.com",
+    address: "Aarhus",
+    photo: "/images/volunteer2.jpg",
+    services: ["Gardening", "Companionship"],
+    availability: "Weekends, 4pm - 8pm",
+  },
+];
+
+const VolunteersList = () => {
+  const [volunteers, setVolunteers] = useState([]);
+
+  useEffect(() => {
+    // simulate API fetch
+    setTimeout(() => {
+      setVolunteers(mockVolunteers);
+    }, 500);
+  }, []);
+
+  return (
+    <div className={styles.container}>
+      <h2 className={styles.title}>Available Volunteers</h2>
+      <div className={styles.grid}>
+        {volunteers.map((v) => (
+          <Volunteer key={v.id} volunteer={v} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default VolunteersList;

--- a/app-next/components/VolunteerList/VolunteerList.module.css
+++ b/app-next/components/VolunteerList/VolunteerList.module.css
@@ -1,0 +1,95 @@
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 4rem 2rem;
+}
+
+.title {
+  font-family: Arial, sans-serif;
+  font-size: 3rem;
+  color: #333;
+  text-align: center;
+  font-weight: bold;
+  margin-bottom: 3rem;
+  animation: fadeInDown 0.8s ease-out forwards;
+}
+
+@keyframes fadeInDown {
+  from {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 2rem;
+  animation: fadeInGrid 1s ease-out forwards;
+  opacity: 0;
+}
+
+@keyframes fadeInGrid {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.loading,
+.error,
+.empty {
+  text-align: center;
+  font-size: 1.2rem;
+  padding: 3rem 0;
+}
+
+.loading::before {
+  content: "";
+  display: block;
+  margin: 0 auto 1rem;
+  width: 40px;
+  height: 40px;
+  border: 5px solid rgba(0, 0, 0, 0.1);
+  border-top-color: #1e90ff;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 992px) {
+  .grid {
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  }
+}
+
+@media (max-width: 768px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+  .title {
+    font-size: 2rem;
+    margin-bottom: 2rem;
+  }
+  .loading::before {
+    width: 30px;
+    height: 30px;
+    border-width: 4px;
+  }
+}


### PR DESCRIPTION
I created the Volunteer page that displays all available volunteers. Since the API connection is not ready yet, the page is currently using dummy data, and I have created a Trello task to replace this with real data once the API is available. 

<img width="1047" height="517" alt="Screenshot 2025-09-08 at 16 59 40" src="https://github.com/user-attachments/assets/2a68f73c-79ff-4e5e-a7a1-5ff6dab6480b" />



I also added a Volunteer detail page that allows users to view extended information about each volunteer. This page will later also include the ratings we discussed, and I’ve added a Trello task for that as well. 

<img width="850" height="435" alt="Screenshot 2025-09-08 at 16 59 47" src="https://github.com/user-attachments/assets/0d2dc408-e0f2-4d3a-969d-96a97da38ab9" />


In addition, I updated the header and navigation by changing the page title and navigation links, and I fixed the front page button so that clicking “Volunteers” now correctly directs users to the Volunteer page.

<img width="1426" height="55" alt="Screenshot 2025-09-08 at 16 59 54" src="https://github.com/user-attachments/assets/3e4ad9e0-23ed-4c3c-9121-25f43179b78a" />
<img width="411" height="234" alt="Screenshot 2025-09-08 at 17 00 08" src="https://github.com/user-attachments/assets/ed038ac5-c1b7-4e3d-91a5-fe4db39449b9" />



